### PR TITLE
fix: handle razorpay failed status

### DIFF
--- a/lib/payment.js
+++ b/lib/payment.js
@@ -346,11 +346,29 @@ export const PaymentProvider = ({ children }) => {
          setWebViewSource({ html: '' })
          setShowWebView(false)
          state.onPaymentSuccessCallback()
-         navigation.goBack()
-         navigation.goBack()
-         navigation.navigate('OrderTracking', {
-            cartId: cartPayment.cartId,
+         navigation.reset({
+            routes: [
+               {
+                  name: 'TabMenu',
+               },
+               {
+                  name: 'OrderTracking',
+                  params: {
+                     cartId: cartPayment.cartId,
+                  },
+               },
+            ],
          })
+      }
+      if (cartPayment?.paymentStatus === 'FAILED') {
+         if (
+            cartPayment.availablePaymentOption.supportedPaymentOption
+               .supportedPaymentCompany.label === 'razorpay'
+         ) {
+            razorpayEventHandler()
+         }
+         setWebViewSource({ html: '' })
+         setShowWebView(false)
       }
    }, [cartPayment?.paymentStatus])
 
@@ -390,7 +408,7 @@ export const PaymentProvider = ({ children }) => {
                            cartPayment?.metaData.customerkeycloakId
                         )),
                   })
-                  if (state.paymentLifeCycleState === 'INITIALIZE') {
+                  if (isProcessingPayment) {
                      displayRazorpay(options, setShowWebView, setWebViewSource)
                   }
                })()


### PR DESCRIPTION
- Handled Razorpay failed Status.
- Reinitiate the Razorpay payment screen when a `CREATED` Razorpay payment is pending for the current cart of that user.